### PR TITLE
Refactor: Move Token Generation Logic to UserService

### DIFF
--- a/app/api/auth_api.py
+++ b/app/api/auth_api.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session
 from app.core.database import get_db
-from app.schemas.user_sh import UserCreate, UserOut, UserLogin
+from app.schemas.user_sh import UserCreate, UserOut, UserLogin, Token
 from app.services.user_service import UserService
 from app.core.security import create_access_token
 from app.api.deps import get_current_user
@@ -18,19 +18,18 @@ def register(user_data: UserCreate, db: Session = Depends(get_db)):
     service = UserService(db)
     return service.register_user(user_data)
 
-@router.post("/login", summary="User Login")
+@router.post("/login", response_model=Token)
 def login(
     form_data: OAuth2PasswordRequestForm = Depends(), 
     db: Session = Depends(get_db)
 ):
     service = UserService(db)
-    user = service.authenticate_user_by_form(form_data.username, form_data.password)
+    login_result = service.authenticate_user(form_data.username, form_data.password)
     
-    if not user:
-        raise HTTPException(status_code=401, detail="Worng email or password")
+    if not login_result:
+        raise HTTPException(status_code=401, detail="Wrong email or password")
     
-    access_token = create_access_token(data={"sub": str(user.id)})
-    return {"access_token": access_token, "token_type": "bearer"}
+    return login_result
 
 @router.get("/me",
             summary="Get Current User Profile",

--- a/app/schemas/user_sh.py
+++ b/app/schemas/user_sh.py
@@ -28,3 +28,11 @@ class UserOut(BaseModel):
 class UserLogin(BaseModel):
     email: EmailStr
     password: str
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str
+
+class TokenData(BaseModel):
+    user_id: Optional[str] = None


### PR DESCRIPTION
## Overview
This PR moves the token generation logic from the API layer to the Service layer in order to standardize the architecture.

## Changes
- **Schemas:** `Token` and `TokenData` schemas have been added.
- **Service:** The `authenticate_user` method in `UserService` has been updated to prepare the JWT token package after authentication.
- **API:** The login endpoint in `auth_api.py` has been simplified and freed from business logic.

## Impact
- The API layer (Controller) now only handles requests.
- Testability has increased because the business logic is centralized.
- The project has become more compliant with layered architecture principles.

**Closes #1**